### PR TITLE
feat: Initial monorepo structure for Open Codex Web UI

### DIFF
--- a/open-codex-web/package.json
+++ b/open-codex-web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "open-codex-web",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Web UI for Open Codex CLI",
+  "scripts": {
+    "install:all": "pnpm install --recursive",
+    "dev:backend": "pnpm --filter @open-codex-web/backend dev",
+    "dev:frontend": "pnpm --filter @open-codex-web/frontend dev",
+    "dev": "concurrently \"npm:dev:backend\" \"npm:dev:frontend\"",
+    "build:backend": "pnpm --filter @open-codex-web/backend build",
+    "build:frontend": "pnpm --filter @open-codex-web/frontend build",
+    "build": "pnpm run build:backend && pnpm run build:frontend"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "nodemon": "^3.1.0"
+  }
+}

--- a/open-codex-web/packages/backend/package.json
+++ b/open-codex-web/packages/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@open-codex-web/backend",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "nodemon src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
+    "nodemon": "^3.1.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/open-codex-web/packages/backend/src/index.ts
+++ b/open-codex-web/packages/backend/src/index.ts
@@ -1,0 +1,15 @@
+import express, { Request, Response } from 'express';
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+
+// Simple health check endpoint
+app.get('/api/health', (req: Request, res: Response) => {
+  res.json({ status: 'ok', message: 'Backend is healthy' });
+});
+
+app.listen(port, () => {
+  console.log(`Backend server listening on http://localhost:${port}`);
+});

--- a/open-codex-web/packages/backend/tsconfig.json
+++ b/open-codex-web/packages/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/open-codex-web/packages/frontend/index.html
+++ b/open-codex-web/packages/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Open Codex Web UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/open-codex-web/packages/frontend/package.json
+++ b/open-codex-web/packages/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@open-codex-web/frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/open-codex-web/packages/frontend/src/App.css
+++ b/open-codex-web/packages/frontend/src/App.css
@@ -1,0 +1,1 @@
+/* This file is intentionally empty for now. */

--- a/open-codex-web/packages/frontend/src/App.tsx
+++ b/open-codex-web/packages/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Placeholder from './components/Placeholder';
+import './App.css'; // Create this empty file
+
+function App() {
+  return (
+    <div className="App">
+      <Placeholder />
+    </div>
+  );
+}
+
+export default App;

--- a/open-codex-web/packages/frontend/src/components/Placeholder.tsx
+++ b/open-codex-web/packages/frontend/src/components/Placeholder.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+
+interface HealthStatus {
+  status: string;
+  message?: string;
+}
+
+const Placeholder: React.FC = () => {
+  const [backendStatus, setBackendStatus] = useState<HealthStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/health') // Proxied by Vite
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data: HealthStatus) => {
+        setBackendStatus(data);
+      })
+      .catch(err => {
+        console.error("Failed to fetch backend status:", err);
+        setError(err.message);
+        setBackendStatus({ status: 'error', message: 'Failed to connect to backend' });
+      });
+  }, []);
+
+  return (
+    <div>
+      <h1>Open Codex Web UI - Placeholder</h1>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {backendStatus ? (
+        <p>
+          Backend Status: <span style={{ color: backendStatus.status === 'ok' ? 'green' : 'red' }}>{backendStatus.status}</span>
+          {backendStatus.message && ` - ${backendStatus.message}`}
+        </p>
+      ) : (
+        <p>Loading backend status...</p>
+      )}
+    </div>
+  );
+};
+
+export default Placeholder;

--- a/open-codex-web/packages/frontend/src/index.css
+++ b/open-codex-web/packages/frontend/src/index.css
@@ -1,0 +1,1 @@
+/* This file is intentionally empty for now. */

--- a/open-codex-web/packages/frontend/src/main.tsx
+++ b/open-codex-web/packages/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css' // We'll create this empty file next
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/open-codex-web/packages/frontend/src/vite-env.d.ts
+++ b/open-codex-web/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/open-codex-web/packages/frontend/tsconfig.json
+++ b/open-codex-web/packages/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/open-codex-web/packages/frontend/tsconfig.node.json
+++ b/open-codex-web/packages/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/open-codex-web/packages/frontend/vite.config.ts
+++ b/open-codex-web/packages/frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000, // Frontend runs on port 3000
+    proxy: {
+      // Proxy API requests to the backend
+      '/api': {
+        target: 'http://localhost:3001', // Backend runs on port 3001
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/open-codex-web/pnpm-workspace.yaml
+++ b/open-codex-web/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
Sets up the foundational monorepo for the Open Codex Web UI project using pnpm workspaces.

This commit includes:
- A root directory `open-codex-web` with a root `package.json` and `pnpm-workspace.yaml`.
- Scripts in the root `package.json` to manage and run frontend and backend concurrently (e.g., `pnpm dev`).

- `packages/backend`:
  - A Node.js/Express.js application with TypeScript.
  - Basic server setup in `src/index.ts`.
  - A `/api/health` endpoint to check backend status.
  - `package.json` with `dev`, `build`, and `start` scripts.
  - `tsconfig.json` for TypeScript compilation.

- `packages/frontend`:
  - A React application scaffolded with Vite and TypeScript.
  - `vite.config.ts` configured to proxy `/api` requests to the backend (running on port 3001).
  - A placeholder component `src/components/Placeholder.tsx` that fetches data from the backend's `/api/health` endpoint.
  - `App.tsx` updated to display the placeholder component.
  - `package.json` with standard Vite scripts (`dev`, `build`).
  - `tsconfig.json` and `tsconfig.node.json`.

This provides the basic structure to start developing the web UI, allowing concurrent development of the frontend and backend, and demonstrating basic communication between them.